### PR TITLE
Fix clash with std::vector

### DIFF
--- a/optimization.cpp
+++ b/optimization.cpp
@@ -22,7 +22,7 @@ using namespace std;
 const double ERROR_X = 1.0e-4;
 
 double ran1(long *idum);
-double *vector(long nl, long nh);
+double *vec(long nl, long nh);
 void free_vector(double *v, long nl, long nh);
 double **matrix(long nrl, long nrh, long ncl, long nch);
 void free_matrix(double **m, long nrl, long nrh, long ncl, long nch);
@@ -96,7 +96,7 @@ void nrerror(const char *error_text)
 	throw error_text;
 }
 
-double *vector(long nl, long nh)
+double *vec(long nl, long nh)
 /* allocate a double vector with subscript range v[nl..nh] */
 {
 	double *v;
@@ -635,12 +635,12 @@ void Optimization::dfpmin(double p[], int n, double lower[], double upper[], dou
 	double den,fac,fad,fae,fp,stpmax,sum=0.0,sumdg,sumxi,temp,test;
 	double *dg,*g,*hdg,**hessin,*pnew,*xi;
 
-	dg=vector(1,n);
-	g=vector(1,n);
-	hdg=vector(1,n);
+	dg=vec(1,n);
+	g=vec(1,n);
+	hdg=vec(1,n);
 	hessin=matrix(1,n,1,n);
-	pnew=vector(1,n);
-	xi=vector(1,n);
+	pnew=vec(1,n);
+	xi=vec(1,n);
 	fp = derivativeFunk(p,g);
 	for (i=1;i<=n;i++) {
 		for (j=1;j<=n;j++) hessin[i][j]=0.0;


### PR DESCRIPTION
Compilation fails on clang due to a naming clash:

```
/tmp/mpboot-20200316-35235-1sckd9h/mpboot-1.1.0-Source/optimization.cpp:638:5: error: reference to 'vector' is ambiguous
        dg=vector(1,n);
           ^
/tmp/mpboot-20200316-35235-1sckd9h/mpboot-1.1.0-Source/optimization.cpp:99:9: note: candidate found by name lookup is 'vector'
double *vector(long nl, long nh)
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:217:28: note: 
      candidate found by name lookup is 'std::__1::vector'
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
```

This pull request renames `vector` in optimization.cpp to avoid the conflict.