### PR TITLE
Fix stackoverflow error in parseFile function

### DIFF
--- a/mtree.cpp
+++ b/mtree.cpp
@@ -580,7 +580,7 @@ void MTree::parseFile(istream &infile, char &ch, Node* &root, double &branch_len
 {
     Node *node;
     int maxlen = 10000;
-    char seqname[10000];
+    string seqname;
     int seqlen;
     double brlen;
     branch_len = -1.0;
@@ -615,6 +615,7 @@ void MTree::parseFile(istream &infile, char &ch, Node* &root, double &branch_len
     }
     // now read the node name
     seqlen = 0;
+    seqname = "";
     char end_ch = 0;
     if (ch == '\'' || ch == '"') end_ch = ch;
 
@@ -623,11 +624,15 @@ void MTree::parseFile(istream &infile, char &ch, Node* &root, double &branch_len
         if (end_ch == 0) {
             if (is_newick_token(ch) || controlchar(ch)) break;
         }
-        seqname[seqlen++] = ch;
+        // seqname[seqlen++] = ch;
+        seqname += ch;
+        seqlen ++;
         ch = infile.get();
         in_column++;
         if (end_ch != 0 && ch == end_ch) {
-            seqname[seqlen++] = ch;
+            // seqname[seqlen++] = ch;
+            seqname += ch;
+            seqlen ++;
             break;
         }
     }
@@ -635,7 +640,7 @@ void MTree::parseFile(istream &infile, char &ch, Node* &root, double &branch_len
         ch = readNextChar(infile, ch);
     if (seqlen == maxlen)
         throw "Too long name ( > 100)";
-    seqname[seqlen] = 0;
+    // seqname[seqlen] = 0;
     if (seqlen == 0 && root->isLeaf())
         throw "A taxon has no name.";
     if (seqlen > 0)
@@ -654,9 +659,11 @@ void MTree::parseFile(istream &infile, char &ch, Node* &root, double &branch_len
     {
         ch = readNextChar(infile);
         seqlen = 0;
+        seqname = "";
         while (!is_newick_token(ch) && !controlchar(ch) && !infile.eof() && seqlen < maxlen)
         {
-            seqname[seqlen] = ch;
+            seqname += ch;
+            // seqname[seqlen] = ch;
             seqlen++;
             ch = infile.get();
             in_column++;
@@ -665,8 +672,12 @@ void MTree::parseFile(istream &infile, char &ch, Node* &root, double &branch_len
             ch = readNextChar(infile, ch);
         if (seqlen == maxlen || infile.eof())
             throw "branch length format error.";
-        seqname[seqlen] = 0;
-        branch_len = convert_double(seqname);
+        // seqname[seqlen] = 0;
+        // convert seqname to char array
+        // char* seqnameArray = new char[seqlen + 1];
+        // for (int i = 0; i <= seqlen; i++)
+        //     seqnameArray[i] = seqname[i];
+        branch_len = convert_double(seqname.c_str());
     }
 }
 


### PR DESCRIPTION
Problem: In the parseFile function, Mpboot used a sequence name array with fixed allocated stack memory. Consequently, this leads to a stack overflow error when there are too many '(' characters in the newick treefile, resulting in excessive recursion and stack overflow.

Solution: Utilize std::string instead.