### PR TITLE
Fix CI for macOS

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         chipset_arch: ["sse4", "avx"]
-        os: [macos-latest]
+        os: [macos-13]
     permissions:
       contents: write
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Change the OS version to macos-13, as it is the latest version supported by the GitHub runner for the Intel arch.